### PR TITLE
Issue 40 iOS7 Crash

### DIFF
--- a/src/Plugin.Fingerprint.iOS/FingerprintImplementation.cs
+++ b/src/Plugin.Fingerprint.iOS/FingerprintImplementation.cs
@@ -5,6 +5,7 @@ using Foundation;
 using LocalAuthentication;
 using ObjCRuntime;
 using Plugin.Fingerprint.Abstractions;
+using UIKit;
 
 namespace Plugin.Fingerprint
 {
@@ -129,21 +130,23 @@ namespace Plugin.Fingerprint
         }
 
         private void CreateLaContext()
-        {
-            if (Class.GetHandle(typeof(LAContext)) == IntPtr.Zero)
-               return;
+        {           
 
             var info = new NSProcessInfo();
 #if __MAC__
             var minVersion = new NSOperatingSystemVersion(10, 12, 0);
+			if (!info.IsOperatingSystemAtLeastVersion(minVersion))
+				return;
 #else
-            var minVersion = new NSOperatingSystemVersion(8, 0, 0);
+   			// IsOperatingSystemAtLeastVersion is only available since iOS8, so use CheckSystemVersion instead or plugin will crash on iOS7 and below
+			if (!UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
+				return;
 #endif
-
-            if (info.IsOperatingSystemAtLeastVersion(minVersion))
-            {
-                _context = new LAContext();
-            }
+			// Check LAContext is not available on iOS7 and below, so check LAContext after checking iOS version.
+			if (Class.GetHandle(typeof(LAContext)) == IntPtr.Zero)
+				return;
+			
+            _context = new LAContext();            
         }
     }
 }


### PR DESCRIPTION
- IsOperatingSystemAtLeastVersion is only available since iOS8, so use CheckSystemVersion instead or plugin will crash on iOS7 and below
- Check LAContext is not available on iOS7 and below, so check LAContext after checking iOS version.