### PR TITLE
Key chain/ key store based implementation

### DIFF
--- a/src/Plugin.Fingerprint.Abstractions.Mac/Plugin.Fingerprint.Abstractions.Mac.csproj
+++ b/src/Plugin.Fingerprint.Abstractions.Mac/Plugin.Fingerprint.Abstractions.Mac.csproj
@@ -52,8 +52,17 @@
     <Compile Include="..\Plugin.Fingerprint.Abstractions\FingerprintImplementationBase.cs">
       <Link>FingerprintImplementationBase.cs</Link>
     </Compile>
+    <Compile Include="..\Plugin.Fingerprint.Abstractions\GetSecureValueResult.cs">
+      <Link>GetSecureValueResult.cs</Link>
+    </Compile>
     <Compile Include="..\Plugin.Fingerprint.Abstractions\IFingerprint.cs">
       <Link>IFingerprint.cs</Link>
+    </Compile>
+    <Compile Include="..\Plugin.Fingerprint.Abstractions\SecureValueResult.cs">
+      <Link>SecureValueResult.cs</Link>
+    </Compile>
+    <Compile Include="..\Plugin.Fingerprint.Abstractions\SecureValueResultStatus.cs">
+      <Link>SecureValueResultStatus.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Plugin.Fingerprint.Abstractions/FingerprintImplementationBase.cs
+++ b/src/Plugin.Fingerprint.Abstractions/FingerprintImplementationBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Plugin.Fingerprint.Abstractions
@@ -25,5 +27,53 @@ namespace Plugin.Fingerprint.Abstractions
 
         public abstract Task<FingerprintAvailability> GetAvailabilityAsync();
         protected abstract Task<FingerprintAuthenticationResult> NativeAuthenticateAsync(AuthenticationRequestConfiguration authRequestConfig, CancellationToken cancellationToken);
+        protected abstract Task<SecureValueResult> NativeSetSecureValue(string serviceId, KeyValuePair<string, string> value);
+        protected abstract Task<SecureValueResult> NativeRemoveSecureValue(string serviceId, string key);
+        protected abstract Task<GetSecureValueResult> NativeGetSecureValue(string serviceId, string key, string reason);
+
+        public async Task<SecureValueResult> SetSecureValue(string serviceId, KeyValuePair<string, string> value)
+        {
+            if (serviceId == null)
+                throw new ArgumentNullException(nameof(serviceId));
+
+            if (string.IsNullOrEmpty(value.Key) || string.IsNullOrEmpty(value.Value))
+                throw new ArgumentNullException(nameof(value), "Key or value cannot be empty");            
+
+            if (!await IsAvailableAsync())
+                return new SecureValueResult { Status = SecureValueResultStatus.NotAvailable };
+
+            return await NativeSetSecureValue(serviceId, value);
+        }
+
+        public async Task<SecureValueResult> RemoveSecureValue(string serviceId, string key)
+        {
+            if (serviceId == null)
+                throw new ArgumentNullException(nameof(serviceId));
+
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));            
+
+            if (!await IsAvailableAsync())
+                return new SecureValueResult { Status = SecureValueResultStatus.NotAvailable };
+
+            return await NativeRemoveSecureValue(serviceId, key);
+        }
+
+        public async Task<GetSecureValueResult> GetSecureValue(string serviceId, string key, string reason)
+        {
+            if (serviceId == null)
+                throw new ArgumentNullException(nameof(serviceId));
+
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (reason == null)
+                throw new ArgumentNullException(nameof(reason));
+
+            if (!await IsAvailableAsync())
+                return new GetSecureValueResult { Status = SecureValueResultStatus.NotAvailable };
+
+            return await NativeGetSecureValue(serviceId, key, reason);
+        }
     }
 }

--- a/src/Plugin.Fingerprint.Abstractions/GetSecureValueResult.cs
+++ b/src/Plugin.Fingerprint.Abstractions/GetSecureValueResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Plugin.Fingerprint.Abstractions
+{
+    public class GetSecureValueResult
+    {           
+        /// <summary>
+        /// Status of the operation.
+        /// </summary>
+        public SecureValueResultStatus Status { get; set; }
+
+        /// <summary>
+        /// The value read from the OS secure store after successful fingerprint authentication.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Reason for the unsuccessful operation.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/Plugin.Fingerprint.Abstractions/IFingerprint.cs
+++ b/src/Plugin.Fingerprint.Abstractions/IFingerprint.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Plugin.Fingerprint.Abstractions
@@ -38,5 +39,9 @@ namespace Plugin.Fingerprint.Abstractions
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Authentication result</returns>
         Task<FingerprintAuthenticationResult> AuthenticateAsync(AuthenticationRequestConfiguration authRequestConfig, CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<SecureValueResult> SetSecureValue(string serviceId, KeyValuePair<string, string> value);
+        Task<SecureValueResult> RemoveSecureValue(string serviceId, string key);
+        Task<GetSecureValueResult> GetSecureValue(string serviceId, string key, string reason);
     }
 }

--- a/src/Plugin.Fingerprint.Abstractions/Plugin.Fingerprint.Abstractions.csproj
+++ b/src/Plugin.Fingerprint.Abstractions/Plugin.Fingerprint.Abstractions.csproj
@@ -40,7 +40,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthenticationRequestConfiguration.cs" />
+    <Compile Include="GetSecureValueResult.cs" />
+    <Compile Include="SecureValueResult.cs" />
     <Compile Include="FingerprintAuthenticationResult.cs" />
+    <Compile Include="SecureValueResultStatus.cs" />
     <Compile Include="FingerprintAuthenticationResultStatus.cs" />
     <Compile Include="FingerprintAvailability.cs" />
     <Compile Include="FingerprintImplementationBase.cs" />

--- a/src/Plugin.Fingerprint.Abstractions/SecureValueResult.cs
+++ b/src/Plugin.Fingerprint.Abstractions/SecureValueResult.cs
@@ -1,0 +1,15 @@
+﻿namespace Plugin.Fingerprint.Abstractions
+{
+    public class SecureValueResult
+    {      
+        /// <summary>
+        /// Status of the operation.
+        /// </summary>
+        public SecureValueResultStatus Status { get; set; }
+
+        /// <summary>
+        /// Reason for the unsuccessful operation.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/Plugin.Fingerprint.Abstractions/SecureValueResultStatus.cs
+++ b/src/Plugin.Fingerprint.Abstractions/SecureValueResultStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace Plugin.Fingerprint.Abstractions
+{
+    public enum SecureValueResultStatus
+    {
+        Unknown,
+        Succeeded,        
+        UnknownError,
+        NotAvailable
+    }
+}

--- a/src/Plugin.Fingerprint.Android/Contract/AndroidFingerprintImplementationBase.cs
+++ b/src/Plugin.Fingerprint.Android/Contract/AndroidFingerprintImplementationBase.cs
@@ -1,6 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Plugin.Fingerprint.Abstractions;
+using System.Collections.Generic;
+using System;
 
 namespace Plugin.Fingerprint.Contract
 {
@@ -21,5 +23,32 @@ namespace Plugin.Fingerprint.Contract
         }
 
         public abstract Task<FingerprintAuthenticationResult> AuthenticateNoDialogAsync(IAuthenticationFailedListener failedListener, CancellationToken cancellationToken);
+
+        protected override Task<SecureValueResult> NativeSetSecureValue(string serviceId, KeyValuePair<string, string> value)
+        {
+            return Task.FromResult(new SecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<SecureValueResult> NativeRemoveSecureValue(string serviceId, string key)
+        {
+            return Task.FromResult(new SecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<GetSecureValueResult> NativeGetSecureValue(string serviceId, string key, string reason)
+        {
+            return Task.FromResult(new GetSecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
     }
 }

--- a/src/Plugin.Fingerprint.NotImplemented/FingerprintImplementation.cs
+++ b/src/Plugin.Fingerprint.NotImplemented/FingerprintImplementation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Plugin.Fingerprint.Abstractions;
+using System.Collections.Generic;
 
 namespace Plugin.Fingerprint
 {
@@ -16,6 +17,33 @@ namespace Plugin.Fingerprint
             return Task.FromResult(new FingerprintAuthenticationResult
             {
                 Status = FingerprintAuthenticationResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<SecureValueResult> NativeSetSecureValue(string serviceId, KeyValuePair<string, string> value)
+        {
+            return Task.FromResult(new SecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<SecureValueResult> NativeRemoveSecureValue(string serviceId, string key)
+        {
+            return Task.FromResult(new SecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<GetSecureValueResult> NativeGetSecureValue(string serviceId, string key, string reason)
+        {
+            return Task.FromResult(new GetSecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
                 ErrorMessage = "Not implemented for the current platform."
             });
         }

--- a/src/Plugin.Fingerprint.UWP/FingerprintImplementation.cs
+++ b/src/Plugin.Fingerprint.UWP/FingerprintImplementation.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Security.Credentials.UI;
 using Plugin.Fingerprint.Abstractions;
+using System.Collections.Generic;
 
 namespace Plugin.Fingerprint
 {
@@ -67,6 +68,33 @@ namespace Plugin.Fingerprint
                 default:
                     return FingerprintAvailability.Unknown;
             }
+        }
+
+        protected override Task<SecureValueResult> NativeSetSecureValue(string serviceId, KeyValuePair<string, string> value)
+        {
+            return Task.FromResult(new SecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<SecureValueResult> NativeRemoveSecureValue(string serviceId, string key)
+        {
+            return Task.FromResult(new SecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
+        }
+
+        protected override Task<GetSecureValueResult> NativeGetSecureValue(string serviceId, string key, string reason)
+        {
+            return Task.FromResult(new GetSecureValueResult
+            {
+                Status = SecureValueResultStatus.NotAvailable,
+                ErrorMessage = "Not implemented for the current platform."
+            });
         }
     }
 }

--- a/src/Sample/SMS.Fingerprint.Sample/MainView.xaml
+++ b/src/Sample/SMS.Fingerprint.Sample/MainView.xaml
@@ -2,19 +2,31 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SMS.Fingerprint.Sample.MainView">
-  <StackLayout Orientation="Vertical" Padding="10">
-    <StackLayout Orientation="Horizontal">
-      <StackLayout.IsVisible>
-        <OnPlatform x:TypeArguments="x:Boolean"
-          iOS="True"
-          Android="True"
-          WinPhone="False" />
-      </StackLayout.IsVisible>
-      <Switch x:Name="swAutoCancel"></Switch>
-      <Label Text="Cancel after 10sec"></Label>
+    <StackLayout>
+        <StackLayout Orientation="Vertical" Padding="10">
+            <Label Text="Fingerprint authentication only" FontSize="Medium"/>
+            <StackLayout Orientation="Horizontal">
+                <StackLayout.IsVisible>
+                    <OnPlatform x:TypeArguments="x:Boolean"
+                        iOS="True"
+                        Android="True"
+                        WinPhone="False" />
+                 </StackLayout.IsVisible>
+                <Switch x:Name="swAutoCancel"></Switch>
+                <Label Text="Cancel after 10sec"></Label>
+            </StackLayout>
+            <Button Text="Authenticate" Clicked="OnAuthenticate"></Button>
+            <Button Text="Authenticate localized" Clicked="OnAuthenticateLocalized"></Button>
+            <Label x:Name="lblAuthenticateStatus"></Label>
+        </StackLayout>
+        <StackLayout Orientation="Vertical" Padding="10">
+        <Label Text="Fingerprint authentication for getting secure values" FontSize="Medium"/>
+
+        <Entry x:Name="entSecureValue" Placeholder="Secure value"/>
+        <Button Text="Add value" Clicked="OnAddSecureValue"></Button>
+        <Button Text="Remove value" Clicked="OnRemoveSecureValue"></Button>
+        <Button Text="Get value" Clicked="OnGetSecureValue"></Button>
+        <Label x:Name="lblSecureValueStatus"></Label>
     </StackLayout>
-    <Button Text="Authenticate" Clicked="OnAuthenticate"></Button>
-    <Button Text="Authenticate localized" Clicked="OnAuthenticateLocalized"></Button>
-    <Label x:Name="lblStatus"></Label>
-  </StackLayout>
+    </StackLayout>
 </ContentPage>

--- a/src/Sample/SMS.Fingerprint.Sample/MainView.xaml.cs
+++ b/src/Sample/SMS.Fingerprint.Sample/MainView.xaml.cs
@@ -3,12 +3,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using Plugin.Fingerprint.Abstractions;
 using Xamarin.Forms;
+using System.Collections.Generic;
 
 namespace SMS.Fingerprint.Sample
 {
     public partial class MainView : ContentPage
     {
         private CancellationTokenSource _cancel;
+        private string _serviceId = Guid.NewGuid().ToString();
+        private string _secureValueKey = "Password";
 
         public MainView()
         {
@@ -18,7 +21,7 @@ namespace SMS.Fingerprint.Sample
         private async void OnAuthenticate(object sender, EventArgs e)
         {
             _cancel = swAutoCancel.IsToggled ? new CancellationTokenSource(TimeSpan.FromSeconds(10)) : new CancellationTokenSource();
-            lblStatus.Text = "";
+            lblAuthenticateStatus.Text = "";
             var result = await Plugin.Fingerprint.CrossFingerprint.Current.AuthenticateAsync("Prove you have fingers!", _cancel.Token);
 
             await SetResultAsync(result);
@@ -27,7 +30,7 @@ namespace SMS.Fingerprint.Sample
         private async void OnAuthenticateLocalized(object sender, EventArgs e)
         {
             _cancel = swAutoCancel.IsToggled ? new CancellationTokenSource(TimeSpan.FromSeconds(10)) : new CancellationTokenSource();
-            lblStatus.Text = "";
+            lblAuthenticateStatus.Text = "";
 
             var dialogConfig = new AuthenticationRequestConfiguration("Beweise, dass du Finger hast!")
             {
@@ -48,8 +51,32 @@ namespace SMS.Fingerprint.Sample
             }
             else
             {
-                lblStatus.Text = $"{result.Status}: {result.ErrorMessage}";
+                lblAuthenticateStatus.Text = $"{result.Status}: {result.ErrorMessage}";
             }
+        }
+
+        private async void OnAddSecureValue(object sender, EventArgs e)
+        {
+            var result = await Plugin.Fingerprint.CrossFingerprint.Current.SetSecureValue(
+                _serviceId, new KeyValuePair<string, string>(_secureValueKey, entSecureValue.Text));
+
+            lblSecureValueStatus.Text = $"{result.Status}: {result.ErrorMessage}";
+        }
+
+        private async void OnRemoveSecureValue(object sender, EventArgs e)
+        {
+            var result = await Plugin.Fingerprint.CrossFingerprint.Current.RemoveSecureValue(
+                _serviceId, _secureValueKey);
+
+            lblSecureValueStatus.Text = $"{result.Status}: {result.ErrorMessage}";
+        }
+
+        private async void OnGetSecureValue(object sender, EventArgs e)
+        {
+            var result = await Plugin.Fingerprint.CrossFingerprint.Current.GetSecureValue(
+               _serviceId, _secureValueKey, "Please authenticate with your fingerprint to continue.");
+
+            lblSecureValueStatus.Text = $"{result.Status}: {result.ErrorMessage}";
         }
     }
 }


### PR DESCRIPTION
Hi

Love your library, especially all the work that's gone into the Android side of things.

For a project I'm working on I need key chain based fingerprint authentication along with the requirement to securely store user credentials for iOS and Android.

It seems like this would be a good addition to your library rather than duplicating the logic to check fingerprint status and all the Android fingerprint logic, what do you think?

This pull request contains an iOS implementation, with stubs for the other platforms, as well as an addition to the sample project. I'll be working on the Android implementation for my project in the coming weeks. If you have any tweaks to the interface or other suggestions le me know and I can make the necessary adjustments.

Let me know if you are happy for me to collaborate on it.


 

