### PR TITLE
Added visibility toggle to show/hide "Use fallback" button on android

### DIFF
--- a/src/Plugin.Fingerprint.Android/Dialog/FingerprintDialogFragment.cs
+++ b/src/Plugin.Fingerprint.Android/Dialog/FingerprintDialogFragment.cs
@@ -64,8 +64,15 @@ namespace Plugin.Fingerprint.Dialog
 
             if (_fallbackButton != null)
             {
-                _fallbackButton.Text = string.IsNullOrWhiteSpace(Configuration.FallbackTitle) ? "Use Fallback" : Configuration.FallbackTitle;
-                _fallbackButton.Click += OnFallback;
+                if (Configuration.AllowAlternativeAuthentication)
+                {
+                    _fallbackButton.Text = string.IsNullOrWhiteSpace(Configuration.FallbackTitle) ? "Use Fallback" : Configuration.FallbackTitle;
+                    _fallbackButton.Click += OnFallback;
+                }
+                else
+                {
+					_fallbackButton.Visibility = ViewStates.Gone;
+                }
             }
             StartAuthenticationAsync();
         }

--- a/src/Sample/SMS.Fingerprint.Sample/MainView.xaml
+++ b/src/Sample/SMS.Fingerprint.Sample/MainView.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="SMS.Fingerprint.Sample.MainView">
@@ -17,7 +17,7 @@
             <StackLayout.IsVisible>
                 <OnPlatform x:TypeArguments="x:Boolean"
                     iOS="True"
-                    Android="False"
+                    Android="True"
                     WinPhone="False" />
             </StackLayout.IsVisible>
             <Switch x:Name="swAllowAlternative"></Switch>


### PR DESCRIPTION
Added visibility toggle to show/hide "Use fallback" button on android's dialog depending on AllowAlternativeAuthentication configuration

If fixes #82 