### PR TITLE
null checks on reason view text assignment

### DIFF
--- a/src/Plugin.Fingerprint.Android/Dialog/FingerprintDialogFragment.cs
+++ b/src/Plugin.Fingerprint.Android/Dialog/FingerprintDialogFragment.cs
@@ -153,7 +153,12 @@ namespace Plugin.Fingerprint.Dialog
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             var view = inflater.Inflate(Resource.Layout.FingerprintDialog, container);
-            view.FindViewById<TextView>(Resource.Id.fingerprint_txtReason).Text = Configuration.Reason;
+
+            var reason = view.FindViewById<TextView>(Resource.Id.fingerprint_txtReason);
+            if(reason != null && Configuration?.Reason != null)
+            {
+                reason.Text = Configuration.Reason;
+            }
 
             _helpText = view.FindViewById<TextView>(Resource.Id.fingerprint_txtHelp);
             _cancelButton = view.FindViewById<Button>(Resource.Id.fingerprint_btnCancel);


### PR DESCRIPTION
This is my attempt at resolving https://github.com/smstuebe/xamarin-fingerprint/issues/67

Added various null checks to hopefully catch whatever edge case is causing this crash.