### PR TITLE
Check for runtime level of >6 when Samsung recommended swapping to th…

### DIFF
--- a/src/MvvmCross.Plugins.Fingerprint.Android/MvvmCross.Plugins.Fingerprint.Android.csproj
+++ b/src/MvvmCross.Plugins.Fingerprint.Android/MvvmCross.Plugins.Fingerprint.Android.csproj
@@ -13,8 +13,7 @@
     <AssemblyName>MvvmCross.Plugins.Fingerprint.Droid</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Plugin.Fingerprint.Android.Samsung/Plugin.Fingerprint.Android.Samsung.csproj
+++ b/src/Plugin.Fingerprint.Android.Samsung/Plugin.Fingerprint.Android.Samsung.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>Plugin.Fingerprint.Android.Samsung</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Plugin.Fingerprint.Android/CrossFingerprint.cs
+++ b/src/Plugin.Fingerprint.Android/CrossFingerprint.cs
@@ -13,10 +13,12 @@ namespace Plugin.Fingerprint
 
         private static IFingerprint CreateFingerprint()
         {
-            var samsungFp = new SamsungFingerprintImplementation();
-
-            if (samsungFp.IsCompatible)
-                return samsungFp;
+            if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.M)
+            {
+                var samsungFp = new SamsungFingerprintImplementation();
+                if (samsungFp.IsCompatible)
+                    return samsungFp;
+            }
 
             return new StandardFingerprintImplementation();
         }

--- a/src/Plugin.Fingerprint.Android/Plugin.Fingerprint.Android.csproj
+++ b/src/Plugin.Fingerprint.Android/Plugin.Fingerprint.Android.csproj
@@ -14,8 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Sample/SMS.Fingerprint.Sample.Droid/Properties/AndroidManifest.xml
+++ b/src/Sample/SMS.Fingerprint.Sample.Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="sms.fingerprint.sample" android:installLocation="auto" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="19" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 	<uses-permission android:name="android.permission.USE_FINGERPRINT" />
 	<uses-permission android:name="com.samsung.android.providers.context.permission.WRITE_USE_APP_FEATURE_SURVEY" />
 	<application android:label="SMS Fingerprint Sample" android:icon="@drawable/xamarin_fingerprint" />

--- a/src/Sample/SMS.Fingerprint.Sample.Droid/SMS.Fingerprint.Sample.Droid.csproj
+++ b/src/Sample/SMS.Fingerprint.Sample.Droid/SMS.Fingerprint.Sample.Droid.csproj
@@ -16,8 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />


### PR DESCRIPTION
…e built in API instead.

"We regret to inform you that all devices including upgrade will no longer be providing the Pass SDK from P OS. Applications can use Android Fingerprint API instead of Pass SDK."

On Pie (Android V9), Samsung Pass appears to be removed completely causing failure to authenticate without this check.

EDIT: Should probably note this was tested on S9+ running BRK9 build of Pie Beta/One UI from Samsung.