### PR TITLE
Update to Xamarin.AndroidX.Biometric 1.1.0

### DIFF
--- a/src/Plugin.Fingerprint/Platforms/Android/AuthenticationHandler.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/AuthenticationHandler.cs
@@ -42,7 +42,7 @@ namespace Plugin.Fingerprint
             var message = errString != null ? errString.ToString() : string.Empty;
             var result = new FingerprintAuthenticationResult { Status = FingerprintAuthenticationResultStatus.Failed, ErrorMessage = message };
 
-            if (errorCode == BiometricPrompt.InterfaceConsts.ErrorLockout)
+            if (errorCode == BiometricPrompt.ErrorLockout)
             {
                 result.Status = FingerprintAuthenticationResultStatus.TooManyAttempts;
             }

--- a/src/Plugin.Fingerprint/Platforms/Android/FingerprintImplementation.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/FingerprintImplementation.cs
@@ -12,6 +12,7 @@ using AndroidX.Biometric;
 using AndroidX.Fragment.App;
 using AndroidX.Lifecycle;
 using Java.Util.Concurrent;
+using System.Linq;
 
 namespace Plugin.Fingerprint
 {
@@ -159,7 +160,8 @@ namespace Plugin.Fingerprint
         private static void TryReleaseLifecycleObserver(ILifecycleOwner lifecycleOwner, BiometricPrompt dialog)
         {
             var promptClass = Java.Lang.Class.FromType(dialog.GetType());
-            var lifecycleObserverField = promptClass.GetDeclaredField("mLifecycleObserver");
+            var fields = promptClass.GetDeclaredFields();
+            var lifecycleObserverField = fields?.FirstOrDefault(f => f.Name == "mLifecycleObserver");
 
             if (lifecycleObserverField is null)
                 return;

--- a/src/Plugin.Fingerprint/Plugin.Fingerprint.csproj
+++ b/src/Plugin.Fingerprint/Plugin.Fingerprint.csproj
@@ -40,7 +40,7 @@
   <!-- Android -->
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <Compile Include="Platforms\Android\**\*.cs" />
-    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.0.1.7" />
+    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">

--- a/src/Sample.Android/Sample.Android.csproj
+++ b/src/Sample.Android/Sample.Android.csproj
@@ -53,7 +53,7 @@
       <Version>1.1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Biometric">
-      <Version>1.0.1.7</Version>
+      <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "2.0.54"
+    "MSBuild.Sdk.Extras": "3.0.23"
   }
 }

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -18,6 +18,13 @@ steps:
   #   inputs:
   #     key: nuget | ./src/Plugin.Fingerprint/packages.lock.json
   #     path: $(NUGET_PACKAGES)
+  
+  - task: DotNetCoreCLI@2
+    displayName: Restore Packages
+    inputs:
+      command: 'restore'
+      projects: './src/Build.sln'
+      feedsToUse: 'select'
 
   - task: MSBuild@1
     displayName: Build & Package


### PR DESCRIPTION
### Description
- Update to AndroidX.Biometric 1.1.0
- Securing TryReleaseLifecycleObserver

I've not made the update to 1.1.01 of AndroidX.Biometric cause of the Typo issue mentioned in [this comment](https://github.com/smstuebe/xamarin-fingerprint/issues/203#issuecomment-788247904).

Small change due to AndroidX.Biometric Update + securing access to the `mLifecycleObserver` field. 
Maybe the entire method `TryReleaseLifecycleObserver` can be removed with this package update.

### Fixes
- #203 
- #205 
