### PR TITLE
Added CryptoObject to Android

### DIFF
--- a/src/Plugin.Fingerprint/Abstractions/FingerprintAuthenticationResultStatus.cs
+++ b/src/Plugin.Fingerprint/Abstractions/FingerprintAuthenticationResultStatus.cs
@@ -40,6 +40,10 @@
         /// </summary>
         NotAvailable,
         /// <summary>
+        /// Error validating cipher.
+        /// </summary>
+        InvalidCipher,
+        /// <summary>
         /// User has denied the usage of the biometric authentication.
         /// </summary>
         Denied

--- a/src/Plugin.Fingerprint/Abstractions/FingerprintAuthenticationResultStatus.cs
+++ b/src/Plugin.Fingerprint/Abstractions/FingerprintAuthenticationResultStatus.cs
@@ -44,6 +44,10 @@
         /// </summary>
         InvalidCipher,
         /// <summary>
+        /// Error the CryptoObject was null while enforced.
+        /// </summary>
+        MissingCryptoObject,
+        /// <summary>
         /// User has denied the usage of the biometric authentication.
         /// </summary>
         Denied

--- a/src/Plugin.Fingerprint/Platforms/Android/CrossFingerprint.Android.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/CrossFingerprint.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Android.App;
+using Plugin.Fingerprint.Platforms.Android.Utils;
 
 namespace Plugin.Fingerprint
 {
@@ -8,7 +9,9 @@ namespace Plugin.Fingerprint
         private static Func<Activity> _activityResolver;
 
         public static Activity CurrentActivity => GetCurrentActivity();
-        
+
+        public static CryptoSettings CryptoSettings { get; set; }
+
         public static void SetCurrentActivityResolver(Func<Activity> activityResolver)
         {
             _activityResolver = activityResolver;

--- a/src/Plugin.Fingerprint/Platforms/Android/FingerprintImplementation.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/FingerprintImplementation.cs
@@ -23,13 +23,17 @@ namespace Plugin.Fingerprint
     {
         private readonly BiometricManager _manager;
         private readonly CryptoObjectHelper _cryptoObjectHelper;
-        private readonly byte[] _cipherSecretBytes;
 
         public FingerprintImplementation()
         {
             _manager = BiometricManager.From(Application.Context);
-            _cryptoObjectHelper = new CryptoObjectHelper(Application.Context.PackageName.ToLower() + "_plugin_fingerprint_authentication_key");
-            //_cipherSecretBytes = new byte[] { 11, 2, 77, 62, 32, 15, 6, 8, 8, 242, 121, 21, 100, 4, 51, 83, 95, 45, 33, 122 };
+
+            if (CrossFingerprint.CryptoSettings == null)
+            {
+                CrossFingerprint.CryptoSettings = new CryptoSettings();
+            }
+
+            _cryptoObjectHelper = new CryptoObjectHelper(CrossFingerprint.CryptoSettings.CryptoKeyName);
         }
 
         public override async Task<AuthenticationType> GetAuthenticationTypeAsync()
@@ -113,7 +117,7 @@ namespace Plugin.Fingerprint
                     Application.Context.GetString(Android.Resource.String.Cancel) :
                     authRequestConfig.CancelTitle;
 
-                var handler = new AuthenticationHandler(_cipherSecretBytes);
+                var handler = new AuthenticationHandler(CrossFingerprint.CryptoSettings.CipherSecretBytes);
                 var builder = new BiometricPrompt.PromptInfo.Builder()
                     .SetTitle(authRequestConfig.Title)
                     .SetConfirmationRequired(authRequestConfig.ConfirmationRequired)

--- a/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoObjectHelper.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoObjectHelper.cs
@@ -17,6 +17,7 @@ namespace Plugin.Fingerprint.Platforms.Android.Utils
          * https://developer.android.com/training/sign-in/biometric-auth
          * https://docs.microsoft.com/en-us/xamarin/android/platform/fingerprint-authentication/creating-a-cryptoobject
          */
+        private static readonly int KeySize = 256;
         private static readonly string KeyAlgorithm = KeyProperties.KeyAlgorithmAes;
         private static readonly string BlockMode = KeyProperties.BlockModeCbc;
         private static readonly string EncryptionPadding = KeyProperties.EncryptionPaddingPkcs7;
@@ -88,6 +89,7 @@ namespace Plugin.Fingerprint.Platforms.Android.Utils
             var keyGenSpec = new KeyGenParameterSpec.Builder(KeyName, KeyStorePurpose.Encrypt | KeyStorePurpose.Decrypt)
                                     .SetBlockModes(BlockMode)
                                     .SetEncryptionPaddings(EncryptionPadding)
+                                    .SetKeySize(KeySize)
                                     .SetUserAuthenticationRequired(true)
                                     .Build();
             keyGen.Init(keyGenSpec);

--- a/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoObjectHelper.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoObjectHelper.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Android.Security.Keystore;
+using AndroidX.Biometric;
+using Java.Security;
+using Javax.Crypto;
+
+namespace Plugin.Fingerprint.Platforms.Android.Utils
+{
+    internal class CryptoObjectHelper
+    {
+        private readonly KeyStore keystore;
+
+        // Fixed Android KeyStore Name
+        static readonly string KeyStoreName = "AndroidKeyStore";
+
+        /*
+         * Algorithm Setup - Based on
+         * https://developer.android.com/training/articles/keystore#java
+         * https://developer.android.com/training/sign-in/biometric-auth
+         * https://docs.microsoft.com/en-us/xamarin/android/platform/fingerprint-authentication/creating-a-cryptoobject
+         */
+
+        static readonly string KeyAlgorithm = KeyProperties.KeyAlgorithmAes;
+        static readonly string BlockMode = KeyProperties.BlockModeCbc;
+        static readonly string EncryptionPadding = KeyProperties.EncryptionPaddingPkcs7;
+        static readonly string Transfomration = $"{KeyAlgorithm}/{BlockMode}/{EncryptionPadding}";
+
+        public string KeyName { get; private set; }
+
+        public CryptoObjectHelper(string keyName)
+        {
+            if (string.IsNullOrEmpty(keyName))
+            {
+                throw new ArgumentException($"{nameof(keyName)} can't be empty or null");
+            }
+
+            this.KeyName = keyName;
+            this.keystore = KeyStore.GetInstance(KeyStoreName);
+            this.keystore.Load(null);
+        }
+
+        public BiometricPrompt.CryptoObject BuildCryptoObject()
+        {
+            var cipher = this.CreateCipher();
+            return new BiometricPrompt.CryptoObject(cipher);
+        }
+
+        private Cipher CreateCipher(int retries = 3)
+        {
+            var key = this.GetKey();
+            var cipher = Cipher.GetInstance(Transfomration);
+
+            try
+            {
+                cipher.Init(CipherMode.EncryptMode, key);
+            }
+            catch (KeyPermanentlyInvalidatedException)
+            {
+                this.keystore.DeleteEntry(this.KeyName);
+                if (retries > 0)
+                {
+                    // Microsoft Docs doesn't overwrite the cipher.
+                    // Without the implementation of GetInstance its hard to say if it doesn't need to be overwritten.
+                    // So this is a just in case
+                    cipher = this.CreateCipher(--retries);
+                }
+                else
+                {
+                    throw new KeyPermanentlyInvalidatedException($"Could not create the cipher for biometric authentication.");
+                }
+            }
+
+            return cipher;
+        }
+
+        private IKey GetKey()
+        {
+            if (!this.keystore.IsKeyEntry(this.KeyName))
+            {
+                this.CreateNewKey();
+            }
+
+            return this.keystore.GetKey(this.KeyName, null);
+        }
+
+        private void CreateNewKey()
+        {
+            var keyGen = KeyGenerator.GetInstance(KeyAlgorithm, KeyStoreName);
+            var keyGenSpec = new KeyGenParameterSpec.Builder(this.KeyName, KeyStorePurpose.Encrypt | KeyStorePurpose.Decrypt)
+                                    .SetBlockModes(BlockMode)
+                                    .SetEncryptionPaddings(EncryptionPadding)
+                                    .SetUserAuthenticationRequired(true)
+                                    .Build();
+            keyGen.Init(keyGenSpec);
+            keyGen.GenerateKey();
+        }
+    }
+}

--- a/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoObjectHelper.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoObjectHelper.cs
@@ -91,6 +91,7 @@ namespace Plugin.Fingerprint.Platforms.Android.Utils
                                     .SetEncryptionPaddings(EncryptionPadding)
                                     .SetKeySize(KeySize)
                                     .SetUserAuthenticationRequired(true)
+                                    .SetInvalidatedByBiometricEnrollment(true)
                                     .Build();
             keyGen.Init(keyGenSpec);
             keyGen.GenerateKey();

--- a/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoSettings.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoSettings.cs
@@ -1,0 +1,53 @@
+﻿using Android.App;
+
+namespace Plugin.Fingerprint.Platforms.Android.Utils
+{
+    public class CryptoSettings
+    {
+        public string CryptoKeyName { get; }
+
+        public byte[] CipherSecretBytes { get; }
+
+        /// <summary>
+        /// Data used for en-/decryption of authentication data
+        /// </summary>
+        /// <param name="cryptoKeyName">Key Name under which the key gets stored. Should be unique to the app</param>
+        /// <param name="cipherSecretBytes">Cipher Secret Bytes used to validate cipher result. Should be unique to the app</param>
+        public CryptoSettings(string cryptoKeyName, byte[] cipherSecretBytes)
+        {
+            this.CryptoKeyName = cryptoKeyName;
+            this.CipherSecretBytes = cipherSecretBytes;
+        }
+
+        /// <summary>
+        /// Data used for en-/decryption of authentication data
+        /// No secret bytes will be used for cipher validation
+        /// </summary>
+        /// <param name="cryptoKeyName">Key Name under which the key gets stored. Should be unique to the app</param>
+        public CryptoSettings(string cryptoKeyName)
+        {
+            this.CryptoKeyName = cryptoKeyName;
+        }
+
+        /// <summary>
+        /// Data used for en-/decryption of authentication data
+        /// Key Name will be automatically set to "{packagename}_plugin_fingerprint_authentication_key"
+        /// </summary>
+        /// <param name="cipherSecretBytes">Cipher Secret Bytes used to validate cipher result. Should be unique to the app</param>
+        public CryptoSettings(byte[] cipherSecretBytes)
+            : this()
+        {
+            this.CipherSecretBytes = cipherSecretBytes;
+        }
+
+        /// <summary>
+        /// Data used for en-/decryption of authentication data
+        /// Key Name will be automatically set to "{packagename}_plugin_fingerprint_authentication_key"
+        /// No secret bytes will be used for cipher validation
+        /// </summary>
+        public CryptoSettings()
+        {
+            this.CryptoKeyName = Application.Context.PackageName.ToLower() + "_plugin_fingerprint_authentication_key";
+        }
+    }
+}

--- a/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoSettings.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoSettings.cs
@@ -9,16 +9,6 @@ namespace Plugin.Fingerprint.Platforms.Android.Utils
         public byte[] CipherSecretBytes { get; }
 
         /// <summary>
-        /// When disabled, manipulating the CryptoObject when verifying the result would valid and return a successful authorization 
-        /// </summary>
-        public bool EnforceCryptoObject { get; set; } = true;
-
-        /// <summary>
-        /// Validate the resulting Cipher to the provided one. CryptoObject can be changed as long as we result in the same valid cipher
-        /// </summary>
-        public bool ValidatedCipher { get; set; } = true;
-
-        /// <summary>
         /// Data used for en-/decryption of authentication data
         /// </summary>
         /// <param name="cryptoKeyName">Key Name under which the key gets stored. Should be unique to the app</param>
@@ -37,6 +27,11 @@ namespace Plugin.Fingerprint.Platforms.Android.Utils
         public CryptoSettings(string cryptoKeyName)
         {
             this.CryptoKeyName = cryptoKeyName;
+
+            var r = new Java.Security.SecureRandom();
+            var secret = new byte[128];
+            r.NextBytes(secret);
+            this.CipherSecretBytes = secret;
         }
 
         /// <summary>

--- a/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoSettings.cs
+++ b/src/Plugin.Fingerprint/Platforms/Android/Utils/CryptoSettings.cs
@@ -9,6 +9,16 @@ namespace Plugin.Fingerprint.Platforms.Android.Utils
         public byte[] CipherSecretBytes { get; }
 
         /// <summary>
+        /// When disabled, manipulating the CryptoObject when verifying the result would valid and return a successful authorization 
+        /// </summary>
+        public bool EnforceCryptoObject { get; set; } = true;
+
+        /// <summary>
+        /// Validate the resulting Cipher to the provided one. CryptoObject can be changed as long as we result in the same valid cipher
+        /// </summary>
+        public bool ValidatedCipher { get; set; } = true;
+
+        /// <summary>
         /// Data used for en-/decryption of authentication data
         /// </summary>
         /// <param name="cryptoKeyName">Key Name under which the key gets stored. Should be unique to the app</param>

--- a/src/Sample.Android/MainActivity.cs
+++ b/src/Sample.Android/MainActivity.cs
@@ -12,7 +12,7 @@ namespace Sample.Droid
         protected override void OnCreate(Bundle savedInstanceState)
         {
             CrossFingerprint.SetCurrentActivityResolver(() => this);
-            CrossFingerprint.CryptoSettings = new CryptoSettings(Application.Context.PackageName + "_bio_authentication_key", new byte[] { 11, 15, 6, 8, 8, 242, 121, 21, 100, 4, 51, 83, 95, 45, 33, 122 });
+            CrossFingerprint.CryptoSettings = new CryptoSettings(Application.Context.PackageName + "_biometric_authentication_key", new byte[] { 11, 15, 6, 8, 8, 242, 121, 21, 100, 4, 51, 83, 95, 45, 33, 122 });
 
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;

--- a/src/Sample.Android/MainActivity.cs
+++ b/src/Sample.Android/MainActivity.cs
@@ -2,6 +2,7 @@
 using Android.Content.PM;
 using Android.OS;
 using Plugin.Fingerprint;
+using Plugin.Fingerprint.Platforms.Android.Utils;
 
 namespace Sample.Droid
 {
@@ -11,6 +12,7 @@ namespace Sample.Droid
         protected override void OnCreate(Bundle savedInstanceState)
         {
             CrossFingerprint.SetCurrentActivityResolver(() => this);
+            CrossFingerprint.CryptoSettings = new CryptoSettings(Application.Context.PackageName + "_bio_authentication_key", new byte[] { 11, 15, 6, 8, 8, 242, 121, 21, 100, 4, 51, 83, 95, 45, 33, 122 });
 
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;


### PR DESCRIPTION
Mentioned in #225 there is a security vulnerability in the current android implementation.
I fixed it with examples from Microsoft and Googles Android documentation.

The current state is tested against the Frida Script (as of writing)
https://codeshare.frida.re/@Saket-taneja/biometricauthenticationbypassnullcryptoobject/

It is not required to make use of the new CryptoSettings class. The default configuration should work for every current implementation of this library.