### PR TITLE
Added ability to specify Authenticator type on Android systems. 

### DIFF
--- a/src/Plugin.Fingerprint/Abstractions/AuthenticationRequestConfiguration.cs
+++ b/src/Plugin.Fingerprint/Abstractions/AuthenticationRequestConfiguration.cs
@@ -1,6 +1,19 @@
 ﻿namespace Plugin.Fingerprint.Abstractions
 {
     /// <summary>
+    /// Enumeration that optionally filters out authenticator methods to use.
+    /// You can filter by strong or weak authentication methods on Android.
+    /// 
+    /// This is currently only used on Android.
+    /// </summary>
+    [System.Flags]
+    public enum AuthenticatorStrength
+    {
+        WEAK = 1,
+        STRONG = 2,
+    }
+
+    /// <summary>
     /// Configuration of the stuff presented to the user.
     /// </summary>
     public class AuthenticationRequestConfiguration
@@ -51,6 +64,12 @@
         /// Default: true
         /// </summary>
         public bool ConfirmationRequired { get; set; } = true;
+
+        /// <summary>
+        /// If set only allows certain authenticators to be used during authentication.
+        /// Can be set to AuthenticatorStrength.STRONG to use only fingerprint, if the face unlocking is configured to be WEAK, but this really depends on the phone manufacturers.
+        /// </summary>
+        public AuthenticatorStrength AuthenticatorStrength { get; set; } = AuthenticatorStrength.STRONG | AuthenticatorStrength.WEAK;
 
         public AuthenticationRequestConfiguration(string title, string reason)
         {


### PR DESCRIPTION
This pull request is a little rough around the edges as I'm not very confident with C# and Visual Studio.
Unfortunately I wasn't able to update MonoAndroid to a version that knows about Android API 30 :(

Allows you to specify STRONG (which should be fingerprint) and WEAK (which should be face), but it depends on the device.

This should fix #231 which in turn should allow [BitWarden](https://community.bitwarden.com/t/enable-disable-individual-biometic-options-for-unlock/36750) https://github.com/bitwarden/mobile/issues/1902 (and other users) to specify the authenticator to use. And if the device has *correctly* configured fingerprint to be `STRONG` and face unlock to be `WEAK` then the app could select which authentication method to use.